### PR TITLE
compatible with Django 1.10

### DIFF
--- a/urldecorators/__init__.py
+++ b/urldecorators/__init__.py
@@ -1,6 +1,7 @@
 
 from django.conf import urls
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
 
 from urldecorators.urlresolvers import RegexURLPattern, RegexURLResolver
 from urldecorators.helpers import get_decorator_tuple
@@ -56,7 +57,7 @@ def _url(regex, view, kwargs=None, name=None, prefix='', decorators=None,
         # For include(...) processing.
         return resolver(regex, view[0], kwargs, *view[1:])
     else:
-        if isinstance(view, basestring):
+        if isinstance(view, six.string_types):
             if not view:
                 raise ImproperlyConfigured('Empty URL pattern view name not permitted (for pattern %r)' % regex)
             if prefix:

--- a/urldecorators/helpers.py
+++ b/urldecorators/helpers.py
@@ -1,6 +1,7 @@
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.decorators import decorator_from_middleware
+from django.utils import six
 
 try:
     from functools import update_wrapper, WRAPPER_ASSIGNMENTS
@@ -9,7 +10,7 @@ except ImportError:
 
 
 def import_if_string(path):
-    if not isinstance(path, basestring):
+    if not isinstance(path, six.string_types):
         return path
     try:
         dot = path.rindex('.')
@@ -18,7 +19,7 @@ def import_if_string(path):
     mod_name, obj_name = path[:dot], path[dot+1:]
     try:
         mod = __import__(mod_name, {}, {}, [''])
-    except ImportError, e:
+    except ImportError as e:
         raise ImproperlyConfigured('Error importing module %s: "%s"'
                                     % (mod_name, e))
     try:


### PR DESCRIPTION
Really like django-urldecorators. I've been using it to implement [flexible security policies on top of Django apps](http://djaodjin.com/blog/drf-angularjs-access-control.blog.html).

This pull request takes into account that `patterns` was removed from Django 1.10 while still being compatible with older versions of Django.
