### PR TITLE
supports Django2.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{2.7,3.3,3.4,3.5}-django1.8,
     py{2.7,3.4,3.5}-django{1.9,1.10},
     py{2.7,3.4,3.5,3.6}-django1.11,
+    py{3.4,3.5,3.6}-django2.0,
 
 
 [testenv]
@@ -25,3 +26,4 @@ deps =
     django1.9: Django>=1.9,<1.10
     django1.10: Django>=1.10,<1.11
     django1.11: Django>=1.11,<1.12
+    django2.0: Django>=2.0,<2.1

--- a/urldecorators/urlresolvers.py
+++ b/urldecorators/urlresolvers.py
@@ -1,6 +1,13 @@
 
 import types
-from django.core import urlresolvers as django_urlresolvers
+try:
+    from django.urls.resolvers import URLPattern as DjangoRegexURLPattern
+    from django.urls import URLResolver as DjangoRegexURLResolver
+except ImportError: # Django<2.0
+    from django.core.urlresolvers import (
+        RegexURLPattern as DjangoRegexURLPattern,
+        RegexURLResolver as DjangoRegexURLResolver
+    )
 from urldecorators.helpers import func_from_callable
 
 
@@ -33,13 +40,13 @@ class DecoratorMixin(object):
         return callback
 
 
-class RegexURLPattern(DecoratorMixin, django_urlresolvers.RegexURLPattern):
+class RegexURLPattern(DecoratorMixin, DjangoRegexURLPattern):
     """
     Django RegexURLPattern with support for decorating resolved views
     """
 
 
-class RegexURLResolver(DecoratorMixin, django_urlresolvers.RegexURLResolver):
+class RegexURLResolver(DecoratorMixin, DjangoRegexURLResolver):
     """
     Django RegexURLResolver with support for decorating resolved views
     """


### PR DESCRIPTION
There has been much changes on how Django manages URL routes in version 2.0. This pull request passes the tests - though I am not sure some url patterns tested are meant to be valid url patterns in Django 2.0.

tox reports SSL issues with py26. I don't have py33, py34 and py35 installed (running low on disk space). Otherwise here are the results of running tox:

      py2.7-django1.4: commands succeeded
      py2.7-django1.5: commands succeeded
      py2.7-django1.6: commands succeeded
      py2.7-django1.7: commands succeeded
      py2.7-django1.8: commands succeeded
    ERROR:   py3.3-django1.8: InterpreterNotFound: python3.3
    ERROR:   py3.4-django1.8: InterpreterNotFound: python3.4
    ERROR:   py3.5-django1.8: InterpreterNotFound: python3.5
      py2.7-django1.9: commands succeeded
      py2.7-django1.10: commands succeeded
    ERROR:   py3.4-django1.9: InterpreterNotFound: python3.4
    ERROR:   py3.4-django1.10: InterpreterNotFound: python3.4
    ERROR:   py3.5-django1.9: InterpreterNotFound: python3.5
    ERROR:   py3.5-django1.10: InterpreterNotFound: python3.5
      py2.7-django1.11: commands succeeded
    ERROR:   py3.4-django1.11: InterpreterNotFound: python3.4
    ERROR:   py3.5-django1.11: InterpreterNotFound: python3.5
      py3.6-django1.11: commands succeeded
    ERROR:   py3.4-django2.0: InterpreterNotFound: python3.4
    ERROR:   py3.5-django2.0: InterpreterNotFound: python3.5
      py3.6-django2.0: commands succeeded
